### PR TITLE
Fix share tool can touch this option

### DIFF
--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -234,7 +234,7 @@ Touch interface
 function FPP.plyCanTouchEnt(ply, ent, touchType)
     ent.FPPCanTouch = ent.FPPCanTouch or {}
     ent.FPPCanTouch[ply] = ent.FPPCanTouch[ply] or 0
-	ent.AllowedPlayers = ent.AllowedPlayers or {}
+    ent.AllowedPlayers = ent.AllowedPlayers or {}
 
     local canTouch = ent.FPPCanTouch[ply]
 

--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -234,11 +234,17 @@ Touch interface
 function FPP.plyCanTouchEnt(ply, ent, touchType)
     ent.FPPCanTouch = ent.FPPCanTouch or {}
     ent.FPPCanTouch[ply] = ent.FPPCanTouch[ply] or 0
+	ent.AllowedPlayers = ent.AllowedPlayers or {}
 
     local canTouch = ent.FPPCanTouch[ply]
+
     -- if an entity is constrained, return the least of the rights
     if ent.FPPRestrictConstraint and ent.FPPRestrictConstraint[ply] then
         canTouch = bit.band(ent.FPPRestrictConstraint[ply], ent.FPPCanTouch[ply])
+    end
+
+    if table.HasValue(ent.AllowedPlayers, ply) then
+        return true
     end
 
     -- return the answer for every touch type if parameter is empty

--- a/lua/weapons/gmod_tool/stools/shareprops.lua
+++ b/lua/weapons/gmod_tool/stools/shareprops.lua
@@ -23,6 +23,11 @@ function TOOL:LeftClick(trace)
 
     local ply = self:GetOwner()
 
+    if ent:CPPIGetOwner() ~= ply then
+        FPP.Notify(ply, "You do not have the right to share this entity.", false)
+        return
+    end
+
     local Physgun = ent.SharePhysgun1 or false
     local GravGun = ent.ShareGravgun1 or false
     local PlayerUse = ent.SharePlayerUse1 or false

--- a/lua/weapons/gmod_tool/stools/shareprops.lua
+++ b/lua/weapons/gmod_tool/stools/shareprops.lua
@@ -7,6 +7,13 @@ function TOOL:RightClick(trace)
     local ent = trace.Entity
     if not IsValid(ent) or CLIENT then return true end
 
+    local ply = self:GetOwner()
+
+    if ent:CPPIGetOwner() ~= ply then
+        FPP.Notify(ply, "You do not have the right to share this entity.", false)
+        return
+    end
+
     ent.SharePhysgun1 = nil
     ent.ShareGravgun1 = nil
     ent.SharePlayerUse1 = nil


### PR DESCRIPTION
Fixes the share tools "can touch this" option for players, Also added a check to only allow the owners to edit the share properties.